### PR TITLE
Patch for nginx

### DIFF
--- a/include/field-converter.php
+++ b/include/field-converter.php
@@ -482,7 +482,10 @@
 			while (ob_get_level()) {
 				ob_end_clean();
 			}
-			apache_setenv('no-gzip', 1);
+			if(function_exists('apache_setenv')) {
+				apache_setenv('no-gzip', 1);
+			}
+			header('X-Accel-Buffering: no');
 			ini_set('zlib.output_compression', 0);
 			set_time_limit(0);
 			ignore_user_abort(true);


### PR DESCRIPTION
+ Function exists check for 'apache_setenv'
+ Added X-Accel-Buffering header with the value 'no'
http://stackoverflow.com/questions/20018803/flush-output-buffer-in-apache-nginx-setup

I think there needs to be another way to do this than with output buffering. It might not work on servers which are behind some caching proxies I think.

Can we just process this inside a normal wordpress ajax request built using add_action('wp_ajax_***', callback); ?
What are the problems we can face if we do it the normal way?