### PR TITLE
Resetting old data of first post

### DIFF
--- a/include/field-converter.php
+++ b/include/field-converter.php
@@ -250,6 +250,7 @@
 			// recursive function
 			$next = array_shift($hierarchy);
 			$row .= $next['name'];
+			$this->data = array();
 			if (!empty($hierarchy)) {
 				// there are still sub fields
 				$count = intval(get_post_meta($post_id, $row, true));


### PR DESCRIPTION
Data of first post was applying for new posts too, this was not resetting, which caused repeat meta data